### PR TITLE
fix: use passthrough resolver for server address

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -258,7 +258,7 @@ func run() {
 		} else {
 			securityOption = grpc.WithTransportCredentials(insecure.NewCredentials())
 		}
-		conn, err = grpc.NewClient(agentCliParam.Server, securityOption, grpc.WithPerRPCCredentials(&auth))
+		conn, err = grpc.NewClient("passthrough:///"+agentCliParam.Server, securityOption, grpc.WithPerRPCCredentials(&auth))
 		if err != nil {
 			printf("与面板建立连接失败: %v", err)
 			retry()


### PR DESCRIPTION
https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md

`NewClient` use `dns` resolver by default instead of `DialContext` using `passthrough`. This seem to broke compatibility with TLS server when the domain resolves to an IPv6 address.